### PR TITLE
Adds color mappings to Log4net appender

### DIFF
--- a/src/LogEntriesCore.Tests/AsyncLoggerFixture.cs
+++ b/src/LogEntriesCore.Tests/AsyncLoggerFixture.cs
@@ -1,6 +1,7 @@
 ﻿namespace LogEntriesCore.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Configuration;
     using System.IO;
     using System.Linq;
@@ -8,6 +9,7 @@
     using System.Threading;
     using LogentriesCore;
     using Xunit;
+    using Attribute = LogentriesCore.Attribute;
 
     public class TestLogger : AsyncLoggerBase
     {
@@ -67,7 +69,7 @@
                 Thread.Sleep(100);
 
                 //Assert
-                Assert.Equal("2bfbea1e-10c3-4419-bdad-7e6435882e1dtest\n", Encoding.UTF8.GetString(ms.ToArray()));
+                Assert.Equal("2bfbea1e-10c3-4419-bdad-7e6435882e1d\x1b[30;47;0mtest\n", Encoding.UTF8.GetString(ms.ToArray()));
             }
         }
         
@@ -142,6 +144,25 @@
 
                 //Assert
                 Assert.Equal(3, Encoding.UTF8.GetString(ms.ToArray()).Count(c => c == '\u2028'));
+            }
+        }
+
+        [Fact]
+        public void ShouldGenerateCorrectAnsiEscapeCodesForStyle()
+        {
+            //Arrange
+            var expected = new Dictionary<Style, string>
+            {
+                { Style.Default, '\x1b' + "[30;47;0m" },
+                { new Style { ForegroundColor = ForegroundColor.White, BackgroundColor = BackgroundColor.Red },  '\x1b' + "[37;41;0m" },
+                { new Style { Attributes = new [] {Attribute.Bold, Attribute.Underline, }},  '\x1b' + "[30;47;1;4m" },
+                { new Style { BackgroundColor = BackgroundColor.Blue },  '\x1b' + "[30;44;0m" }
+            };
+
+            //Act, Assert
+            foreach (var test in expected)
+            {
+                Assert.Equal(test.Key.ToString(), test.Value);    
             }
         }
     }

--- a/src/LogEntriesCore.Tests/AsyncLoggerFixture.cs
+++ b/src/LogEntriesCore.Tests/AsyncLoggerFixture.cs
@@ -153,10 +153,10 @@
             //Arrange
             var expected = new Dictionary<Style, string>
             {
-                { Style.Default, '\x1b' + "[30;47;0m" },
-                { new Style { ForegroundColor = ForegroundColor.White, BackgroundColor = BackgroundColor.Red },  '\x1b' + "[37;41;0m" },
-                { new Style { Attributes = new [] {Attribute.Bold, Attribute.Underline, }},  '\x1b' + "[30;47;1;4m" },
-                { new Style { BackgroundColor = BackgroundColor.Blue },  '\x1b' + "[30;44;0m" }
+                { Style.Default, "\x1b[30;47;0m" },
+                { new Style { ForegroundColor = ForegroundColor.White, BackgroundColor = BackgroundColor.Red },  "\x1b[37;41;0m" },
+                { new Style { Attributes = new List<Attribute> {Attribute.Bold, Attribute.Underline, }},  "\x1b[30;47;1;4m" },
+                { new Style { BackgroundColor = BackgroundColor.Blue },  "\x1b[30;44;0m" }
             };
 
             //Act, Assert

--- a/src/Logentries.sln
+++ b/src/Logentries.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogentriesCore", "LogentriesCore\LogentriesCore.csproj", "{90D6E9FC-7B88-4E1B-B018-8FA742274558}"
 EndProject

--- a/src/LogentriesCore/AsyncLoggerBase.cs
+++ b/src/LogentriesCore/AsyncLoggerBase.cs
@@ -63,7 +63,7 @@
 
         public override string ToString()
         {
-            return '\x1b' + "[" + (int)ForegroundColor + ";" + (int)BackgroundColor + ";" + Attributes.Aggregate("", (s, attribute) => s == "" ? ((int)attribute).ToString() : s + ";" + (int)attribute) + "m";
+            return "\x1b[" + (int)ForegroundColor + ";" + (int)BackgroundColor + ";" + Attributes.Aggregate("", (s, attribute) => s == "" ? ((int)attribute).ToString() : s + ";" + (int)attribute) + "m";
         }
     }
 

--- a/src/LogentriesCore/IAsyncLogger.cs
+++ b/src/LogentriesCore/IAsyncLogger.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public interface IAsyncLogger: IDisposable
+    public interface IAsyncLogger : IDisposable
     {
         bool UseSsl { get; set; }
         bool ImmediateFlush { get; set; }
@@ -11,6 +11,6 @@
         string AccountKey { get; set; }
         int SecurePort { get; set; }
         int Port { get; set; }
-        void AddLine(string line);
+        void AddLine(string line, Style style = null);
     }
 }

--- a/src/LogentriesLog4net/LogentriesAppender.cs
+++ b/src/LogentriesLog4net/LogentriesAppender.cs
@@ -176,7 +176,7 @@
             {
                 return new Style
                 {
-                    Attributes = Attributes,
+                    Attributes = Attributes.Count == 0 ? Style.Default.Attributes : Attributes,
                     ForegroundColor = ForeColor,
                     BackgroundColor = BackColor
                 };


### PR DESCRIPTION
Adds color mappings to log4net appender:

``` xml
<mapping>
  <level value="Debug" />
  <foreColor value="Black" />
  <backColor value="Red" />
  <attribute value="Bold" />
  <attribute value="Underline" />
</mapping>
```

Will result in a red line with black letters underlined and bold when the line is logged with level debug.

@SurajGupta do you have enough experience with NLog to add this to the NLog target.
